### PR TITLE
Add benchmark for dim.Dataset

### DIFF
--- a/R/bm-dataset-taxi-parquet.R
+++ b/R/bm-dataset-taxi-parquet.R
@@ -93,7 +93,7 @@ dataset_taxi_parquet <- Benchmark("dataset_taxi_parquet",
         dim(ds)
       },
       assert = function(result) {
-        stopifnot(identical(result, c(1547741381L, 20L)))
+        stopifnot("dims does not match" = identical(result, c(1547741381L, 20L)))
       }
     )
   ),

--- a/R/bm-dataset-taxi-parquet.R
+++ b/R/bm-dataset-taxi-parquet.R
@@ -87,6 +87,14 @@ dataset_taxi_parquet <- Benchmark("dataset_taxi_parquet",
           identical(sum(result$n), 3069271L)
         )
       }
+    ),
+    count_rows = list(
+      query = function(ds) {
+        dim(ds)
+      },
+      assert = function(result) {
+        stopifnot(identical(result, c(1547741381L, 20L)))
+      }
     )
   ),
   packages_used = function(params) {


### PR DESCRIPTION
In ARROW-9697 I'm working on a count rows method and want to make sure it doesn't regress performance (spoiler alert: it does). 

From what I can see, this also needs to be hooked into ursacomputing/benchmarks before conbench will pick it up.