### PR TITLE
Reduce the compression codecs we default to

### DIFF
--- a/R/bm-read-file.R
+++ b/R/bm-read-file.R
@@ -11,7 +11,7 @@ read_file <- Benchmark("read_file",
   setup = function(source = names(known_sources),
                    # TODO: break out feather_v1 and feather_v2, feather_v2 only in >= 0.17
                    format = c("parquet", "feather"),
-                   compression = c("uncompressed", "snappy", "zstd", "lz4"),
+                   compression = c("uncompressed", "snappy", "lz4"),
                    output = c("arrow_table", "data_frame")) {
     # format defaults to parquet or feather, but can accept fst as well
     format <- match.arg(format, c("parquet", "feather", "fst"))

--- a/R/bm-write-file.R
+++ b/R/bm-write-file.R
@@ -10,7 +10,7 @@
 write_file <- Benchmark("write_file",
   setup = function(source = names(known_sources),
                    format = c("parquet", "feather"),
-                   compression = c("uncompressed", "snappy", "zstd", "lz4"),
+                   compression = c("uncompressed", "snappy", "lz4"),
                    input = c("arrow_table", "data_frame")) {
     # source defaults are retrieved from the function definition (all available
     # known_sources) and then read the source in as a data.frame


### PR DESCRIPTION
 ideally lz4 would only be for feather, but we don't list out defaults like that here