### PR TITLE
Allow one to change the compression of files for TPC-H

### DIFF
--- a/R/bm-tpc-h.R
+++ b/R/bm-tpc-h.R
@@ -203,14 +203,16 @@ find_input_func <- function(func) {
 #' @param scale_factor what scale factor to reference
 #' @param query_id which query is being used
 #' @param format which format
+#' @param compression which compression to use (default: "uncompressed")
 #' @param con a connection
-#' @param memory_map should the file be memory mapped?
+#' @param memory_map should the file be memory mapped? (only relevant for the "native" format with Arrow)
 #'
 #' @export
 get_input_func <- function(engine,
                            scale_factor,
                            query_id,
                            format,
+                           compression = "uncompressed",
                            con = NULL,
                            memory_map = FALSE) {
   # ensure that we have the _base_ tpc-h files (in parquet)
@@ -232,7 +234,8 @@ get_input_func <- function(engine,
       tpch_files[tpch_tables_needed],
       ensure_format,
       FUN.VALUE = character(1),
-      format = format_to_convert
+      format = format_to_convert,
+      compression = compression
     )
 
     # specify readers for each format

--- a/man/get_input_func.Rd
+++ b/man/get_input_func.Rd
@@ -9,6 +9,7 @@ get_input_func(
   scale_factor,
   query_id,
   format,
+  compression = "uncompressed",
   con = NULL,
   memory_map = FALSE
 )
@@ -22,9 +23,11 @@ get_input_func(
 
 \item{format}{which format}
 
+\item{compression}{which compression to use (default: "uncompressed")}
+
 \item{con}{a connection}
 
-\item{memory_map}{should the file be memory mapped?}
+\item{memory_map}{should the file be memory mapped? (only relevant for the "native" format with Arrow)}
 }
 \description{
 This returns a function which will return a table reference with the specified

--- a/tests/testthat/test-bm-tpc-h.R
+++ b/tests/testthat/test-bm-tpc-h.R
@@ -56,6 +56,37 @@ test_that("get_query_func()", {
   expect_type(out, "closure")
 })
 
+# create a temporary directory to be used as the data directory
+temp_dir <- tempfile()
+dir.create(temp_dir)
+
+withr::with_envvar(
+  list(ARROWBENCH_DATA_DIR = temp_dir), {
+    test_that("get_input_func()", {
+      input_func <- get_input_func(
+        engine = "arrow",
+        scale_factor = 0.01,
+        query_id = 1,
+        format = "parquet",
+        compression = "uncompressed"
+      )
+
+      linteitem_ds <- input_func("lineitem")
+      expect_true(grepl("lineitem_0.01.uncompressed.parquet", linteitem_ds$files, fixed = TRUE))
+
+      input_func <- get_input_func(
+        engine = "arrow",
+        scale_factor = 0.01,
+        query_id = 1,
+        format = "parquet",
+        compression = "snappy"
+      )
+
+      linteitem_ds <- input_func("lineitem")
+      expect_true(grepl("lineitem_0.01.snappy.parquet", linteitem_ds$files, fixed = TRUE))
+    })
+  })
+
 test_that("tpch sql queries", {
   query_01 <- get_sql_tpch_query(1)
   expect_equal(


### PR DESCRIPTION
This adds a passing of the `compression` argument to `get_input_func()` so it's easier to test different compressions when using the pattern:

```
library(arrowbench)
library(dplyr, warn.conflicts = FALSE)
library(arrow, warn.conflicts = FALSE)

input_funcs <- get_input_func(
        engine = "arrow",
        scale_factor = 0.01,
        query_id = 1,
        format = "parquet"
      )

get_query_func(1, "arrow")(input_funcs)
```