### PR TITLE
ENG-3640: Add CSV taxi dataset and benchmarks from vroom

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -28,6 +28,7 @@ Imports:
   callr
 Suggests:
     testthat (>= 3.0.0),
+    archive,
     arrow,
     data.table,
     DBI,

--- a/README.md
+++ b/README.md
@@ -41,6 +41,11 @@ can be benchmarked with arrowbench. And then running `R CMD INSTALL .` in a
 terminal (for both, you should do this in the root directory of arrowbench, or 
 pass the path to arrowbench instead of `.`).
 
+Some benchmark data files are downloaded with `download.file(..., method = "wget")`,
+which requires [wget](https://www.gnu.org/software/wget/) to be installed. If not 
+already installed, `wget` is available via most package managers, e.g. with 
+`brew install wget` with Hombrew on MacOS.
+
 ## Contributing
 
 To run DuckDB tests, set `ARROWBENCH_TEST_CUSTOM_DUCKDB` to `1` or another 


### PR DESCRIPTION
Closes #3 by adding the CSV taxi dataset used by vroom to `known_datasets`. Notes:

- Downloading the 7zip archive is slow; expect it to take 30-60m. Uses `method = "wget"` in `download.files()`, which does require it to be installed, but its autorecovery makes it more robust than curl here. 
- The download function will not redownload the archive if it already exists, but will still perform postprocessing if the unpacked directory does not exist. The archive is the real source of truth here and will not change; the postprocessed directory that arrow can read can be blown away at will.
- Adds [{archive}](https://archive.r-lib.org/index.html) to `Suggests:` to unpack 7zip archive.
- Uses a brute-force read lines -> `gsub()` -> write lines approach to remove excess spaces in headers. This is quite slow compared to [vroom's use of sed](https://github.com/tidyverse/vroom/blob/main/inst/bench/download-data.sh#L12), but is cross-platform. Better alternatives welcome.
- gzips the CSVs for the canonical version. I figured they're still minimally edited but just smaller, so it's a nice default format; if we want an uncompressed version we can always write a copy to `temp`. Can remove this if we want.