### PR TITLE
ENG-3908: Test write_csv compression

### DIFF
--- a/R/bm-write-csv.R
+++ b/R/bm-write-csv.R
@@ -10,8 +10,10 @@ write_csv <- Benchmark(
   "write_csv",
   setup = function(source = names(known_sources),
                    writer = "arrow",
+                   compression = "uncompressed",
                    input = c("arrow_table", "data_frame")) {
     writer <- match.arg(writer, c("arrow", "data.table", "vroom", "readr", "base"))
+    compression <- match.arg(compression, c("gzip", "uncompressed"))
     input <- match.arg(input)
 
     # source defaults are retrieved from the function definition (all available
@@ -23,12 +25,20 @@ write_csv <- Benchmark(
     BenchEnvironment(
       write_csv_func = get_csv_writer(writer),
       source = source,
-      df = df
+      df = df,
+      compression = compression
     )
   },
   # delete the results before each iteration
   before_each = {
     result_file <- tempfile(fileext = ".csv")
+    if (compression != "uncompressed") {
+      if (compression == "gzip") {
+        result_file <- paste0(result_file, ".gz")
+      } else {
+        result_file <- paste0(result_file, ".", compression)
+      }
+    }
   },
   # the benchmark to run
   run = {

--- a/R/bm-write-csv.R
+++ b/R/bm-write-csv.R
@@ -79,7 +79,10 @@ get_csv_writer <- function(writer) {
   } else if (writer == "vroom") {
     return(function(..., as_data_frame) vroom::vroom_write(..., delim = ","))
   } else if (writer == "base") {
-    return(function(...) utils::write.csv(..., row.names = FALSE))
+    return(function(df, result_file) {
+      if (tools::file_ext(result_file) == "gz") result_file <- gzfile(result_file)
+      utils::write.csv(df, result_file, row.names = FALSE)
+      })
   } else {
     stop("Unsupported writer: ", writer, call. = FALSE)
   }

--- a/R/bm-write-csv.R
+++ b/R/bm-write-csv.R
@@ -21,24 +21,28 @@ write_csv <- Benchmark(
     source <- ensure_source(source)
     df <- read_source(source, as_data_frame = match.arg(input) == "data_frame")
 
+    if (compression != "uncompressed") {
+      if (compression == "gzip") {
+        ext <- ".csv.gz"
+      } else {
+        ext <- paste0(".csv.", compression)
+      }
+    } else {
+      ext <- ".csv"
+    }
+
     # Map string param name to functions
     BenchEnvironment(
       write_csv_func = get_csv_writer(writer),
       source = source,
       df = df,
-      compression = compression
+      ext = ext
     )
   },
   # delete the results before each iteration
   before_each = {
-    result_file <- tempfile(fileext = ".csv")
-    if (compression != "uncompressed") {
-      if (compression == "gzip") {
-        result_file <- paste0(result_file, ".gz")
-      } else {
-        result_file <- paste0(result_file, ".", compression)
-      }
-    }
+    result_file <- tempfile(fileext = ext)
+
   },
   # the benchmark to run
   run = {

--- a/R/bm-write-csv.R
+++ b/R/bm-write-csv.R
@@ -10,10 +10,10 @@ write_csv <- Benchmark(
   "write_csv",
   setup = function(source = names(known_sources),
                    writer = "arrow",
-                   compression = "uncompressed",
+                   compression = c("uncompressed", "gzip"),
                    input = c("arrow_table", "data_frame")) {
     writer <- match.arg(writer, c("arrow", "data.table", "vroom", "readr", "base"))
-    compression <- match.arg(compression, c("gzip", "uncompressed"))
+    compression <- match.arg(compression, c("uncompressed", "gzip"))
     input <- match.arg(input)
 
     # source defaults are retrieved from the function definition (all available
@@ -21,15 +21,12 @@ write_csv <- Benchmark(
     source <- ensure_source(source)
     df <- read_source(source, as_data_frame = match.arg(input) == "data_frame")
 
-    if (compression != "uncompressed") {
-      if (compression == "gzip") {
-        ext <- ".csv.gz"
-      } else {
-        ext <- paste0(".csv.", compression)
-      }
-    } else {
-      ext <- ".csv"
-    }
+    ext <- switch(
+      compression,
+      uncompressed = ".csv",
+      gzip = ".csv.gz",
+      paste0(".csv.", compression)
+    )
 
     # Map string param name to functions
     BenchEnvironment(


### PR DESCRIPTION
Closes #80 

I have only added in gzip for compression as this works across all writers. I can do further configuration if needed if other compression types are desired. For example do we want to benchmark all the arrow compression options? 

Closed ~Should only be merged once [ARROW-16144](https://issues.apache.org/jira/browse/ARROW-16144) is closed~