### PR TITLE
Store a marker for benchmark versions

### DIFF
--- a/R/benchmark.R
+++ b/R/benchmark.R
@@ -63,6 +63,8 @@
 #' the `teardown()` function.
 #'
 #' @param name string identifier for the benchmark, included in results
+#' @param version string or numeric version object (as returned by
+#' `numeric_version()`) of semantic version for the benchmark
 #' @param setup function having as its arguments the benchmark parameters. See
 #' the `Parametrizing benchmarks` section. This function is called once
 #' to initialize the benchmark context for a given set of parameters.
@@ -87,6 +89,7 @@
 #' @return A `Benchmark` object containing these functions
 #' @export
 Benchmark <- function(name,
+                      version,
                       setup = function(...) BenchEnvironment(...),
                       before_each = TRUE,
                       run = TRUE,
@@ -98,6 +101,7 @@ Benchmark <- function(name,
   structure(
     list(
       name = name,
+      version = numeric_version(version, strict = TRUE),
       setup = setup,
       before_each = substitute(before_each),
       run = substitute(run),

--- a/R/bm-array-altrep-materialization.R
+++ b/R/bm-array-altrep-materialization.R
@@ -12,6 +12,7 @@
 #' @export
 array_altrep_materialization <- Benchmark(
   "array_altrep_materialization",
+  version = "1.0.0",
 
   setup = function(source = names(known_sources),
                    exclude_nulls = FALSE,

--- a/R/bm-array-to-vector.R
+++ b/R/bm-array-to-vector.R
@@ -10,7 +10,10 @@
 #'
 #' @importFrom purrr map flatten
 #' @export
-array_to_vector <- Benchmark("array_to_vector",
+array_to_vector <- Benchmark(
+  "array_to_vector",
+  version = "1.0.0",
+
   setup = function(
       # the only datasets that have any no-null numerics are
       source = c("type_integers", "type_floats"),

--- a/R/bm-dataset-taxi-parquet.R
+++ b/R/bm-dataset-taxi-parquet.R
@@ -4,7 +4,10 @@
 #' * `query` Name of a known query to run; see `dataset_taxi_parquet$cases`
 #'
 #' @export
-dataset_taxi_parquet <- Benchmark("dataset_taxi_parquet",
+dataset_taxi_parquet <- Benchmark(
+  "dataset_taxi_parquet",
+  version = "1.0.0",
+
   setup = function(query = names(dataset_taxi_parquet$cases)) {
     library("dplyr", warn.conflicts = FALSE)
     dataset <- ensure_dataset("taxi_parquet")

--- a/R/bm-df-to-table.R
+++ b/R/bm-df-to-table.R
@@ -6,7 +6,10 @@
 #' * `source` A known-file id to use (it will be read in to a data.frame first)
 #'
 #' @export
-df_to_table <- Benchmark("df_to_table",
+df_to_table <- Benchmark(
+  "df_to_table",
+  version = "1.0.0",
+
   setup = function(source = names(known_sources)) {
     source <- ensure_source(source)
     result_dim <- get_source_attr(source, "dim")

--- a/R/bm-placebo.R
+++ b/R/bm-placebo.R
@@ -6,7 +6,10 @@
 #' `abort` and any other string (including `"base"`) will use base's `stop`
 #'
 #' @keywords internal
-placebo <- Benchmark("placebo",
+placebo <- Benchmark(
+  "placebo",
+  version = "1.0.0",
+
   setup = function(duration = 0.01, error_type = NULL, output_type = NULL, grid = TRUE) {
     BenchEnvironment(placebo_func = function() {
       if (!is.null(output_type)) {

--- a/R/bm-read-csv.R
+++ b/R/bm-read-csv.R
@@ -10,6 +10,8 @@
 #' @importFrom R.utils gzip
 read_csv <- Benchmark(
   "read_csv",
+  version = "1.0.0",
+
   setup = function(source = names(known_sources),
                    reader = "arrow",
                    compression = c("uncompressed", "gzip"),

--- a/R/bm-read-file.R
+++ b/R/bm-read-file.R
@@ -7,7 +7,10 @@
 #' * `output` One of `c("arrow_table", "data_frame")`
 #'
 #' @export
-read_file <- Benchmark("read_file",
+read_file <- Benchmark(
+  "read_file",
+  version = "1.0.0",
+
   setup = function(source = names(known_sources),
                    # TODO: break out feather_v1 and feather_v2, feather_v2 only in >= 0.17
                    format = c("parquet", "feather"),

--- a/R/bm-read-json.R
+++ b/R/bm-read-json.R
@@ -11,6 +11,8 @@
 #' @importFrom R.utils gzip
 read_json <- Benchmark(
   "read_json",
+  version = "1.0.0",
+
   setup = function(source = names(known_sources),
                    reader = c("arrow", "jsonlite", "ndjson", "RcppSimdJson"),
                    compression = c("uncompressed", "gzip"),

--- a/R/bm-remote-dataset.R
+++ b/R/bm-remote-dataset.R
@@ -1,7 +1,10 @@
 #' Remote (S3) dataset reading
 #'
 #' @export
-remote_dataset <- Benchmark("remote_dataset",
+remote_dataset <- Benchmark(
+  "remote_dataset",
+  version = "1.0.0",
+
   setup = function(source = c("taxi_file_list_parquet", "taxi_file_list_feather")) {
     library("dplyr")
     dataset <- ensure_dataset(source, download = FALSE)

--- a/R/bm-row-group-size.R
+++ b/R/bm-row-group-size.R
@@ -9,6 +9,8 @@
 #' @export
 row_group_size <- Benchmark(
   "row_group_size",
+  version = "1.0.0",
+
   setup = function(source = c("fanniemae_2016Q4", "fanniemae_sample"),  # TODO implement more sources
                    queries = c("filters", "everything"),
                    chunk_size = NULL) {

--- a/R/bm-table-to-df.R
+++ b/R/bm-table-to-df.R
@@ -6,7 +6,10 @@
 #' * `source` A known-file id to use (it will be read in to a data.frame first)
 #'
 #' @export
-table_to_df <- Benchmark("table_to_df",
+table_to_df <- Benchmark(
+  "table_to_df",
+  version = "1.0.0",
+
   setup = function(source = names(known_sources)) {
     source <- ensure_source(source)
     result_dim <- get_source_attr(source, "dim")

--- a/R/bm-tpc-h.R
+++ b/R/bm-tpc-h.R
@@ -14,7 +14,10 @@
 #'
 #' @importFrom waldo compare
 #' @export
-tpc_h <- Benchmark("tpc_h",
+tpc_h <- Benchmark(
+  "tpc_h",
+  version = "1.0.0",
+
   setup = function(engine = "arrow",
                    query_id = 1:22,
                    format = c("native", "parquet"),

--- a/R/bm-write-csv.R
+++ b/R/bm-write-csv.R
@@ -8,6 +8,8 @@
 #' @export
 write_csv <- Benchmark(
   "write_csv",
+  version = "1.0.0",
+
   setup = function(source = names(known_sources),
                    writer = "arrow",
                    compression = c("uncompressed", "gzip"),

--- a/R/bm-write-file.R
+++ b/R/bm-write-file.R
@@ -7,7 +7,10 @@
 #' * `input` One of `c("arrow_table", "data_frame")`
 #'
 #' @export
-write_file <- Benchmark("write_file",
+write_file <- Benchmark(
+  "write_file",
+  version = "1.0.0",
+
   setup = function(source = names(known_sources),
                    format = c("parquet", "feather"),
                    compression = c("uncompressed", "snappy", "lz4"),

--- a/R/result.R
+++ b/R/result.R
@@ -163,7 +163,7 @@ BenchmarkResult <- R6Point1Class(
   inherit = Serializable,
 
   public = list(
-    initialize = function(name,
+    initialize = function(benchmark,
                           result,
                           params,
                           tags = NULL,
@@ -173,7 +173,7 @@ BenchmarkResult <- R6Point1Class(
                           options = NULL,
                           output = NULL,
                           rscript = NULL) {
-      self$name <- name
+      self$benchmark <- benchmark
       self$result <- result
       self$params <- params
       self$tags <- tags
@@ -205,7 +205,7 @@ BenchmarkResult <- R6Point1Class(
       out$output <- x$output
 
       # append metadata fields to dataframe as attributes
-      metadata_elements <- c("name", "tags", "info", "context", "github", "options")
+      metadata_elements <- c("benchmark", "tags", "info", "context", "github", "options")
       for (element in metadata_elements) {
         if (element %in% names(x)) {
           attr(out, element) <- x[[element]]
@@ -217,7 +217,20 @@ BenchmarkResult <- R6Point1Class(
   ),
 
   active = list(
-    name = function(name) private$get_or_set_serializable(variable = "name", value = name),
+    benchmark = function(benchmark) {
+      if (!missing(benchmark)) {
+        stopifnot(
+          is.list(benchmark),
+          length(benchmark) == 2L,
+          c("name", "version") %in% names(benchmark),
+          is.character(benchmark[["name"]]),
+          is.numeric_version(numeric_version(benchmark[["version"]], strict = TRUE))
+        )
+        benchmark[["version"]] <- format(benchmark[["version"]])
+        private$to_serialize$benchmark <- benchmark
+      }
+      private$to_serialize$benchmark
+    },
     result = function(result) private$get_or_set_serializable(variable = "result", value = result),
     params = function(params) private$get_or_set_serializable(variable = "params", value = params),
     tags = function(tags) private$get_or_set_serializable(variable = "tags", value = tags),

--- a/R/run.R
+++ b/R/run.R
@@ -201,7 +201,7 @@ run_bm <- function(bm, ..., n_iter = 1, profiling = FALSE, global_params = list(
   )
 
   out <- BenchmarkResult$new(
-    name = bm$name,
+    benchmark = list(name = bm$name, version = bm$version),
     result = do.call(rbind, results),
     params = all_params,
     tags = metadata$tags,

--- a/man/Benchmark.Rd
+++ b/man/Benchmark.Rd
@@ -6,6 +6,7 @@
 \usage{
 Benchmark(
   name,
+  version,
   setup = function(...) BenchEnvironment(...),
   before_each = TRUE,
   run = TRUE,
@@ -17,6 +18,9 @@ Benchmark(
 }
 \arguments{
 \item{name}{string identifier for the benchmark, included in results}
+
+\item{version}{string or numeric version object (as returned by
+\code{numeric_version()}) of semantic version for the benchmark}
 
 \item{setup}{function having as its arguments the benchmark parameters. See
 the \verb{Parametrizing benchmarks} section. This function is called once

--- a/man/array_altrep_materialization.Rd
+++ b/man/array_altrep_materialization.Rd
@@ -5,7 +5,7 @@
 \alias{array_altrep_materialization}
 \title{Benchmark for materializing an altrep Arrow array}
 \format{
-An object of class \code{Benchmark} of length 8.
+An object of class \code{Benchmark} of length 9.
 }
 \usage{
 array_altrep_materialization

--- a/man/array_to_vector.Rd
+++ b/man/array_to_vector.Rd
@@ -5,7 +5,7 @@
 \alias{array_to_vector}
 \title{Benchmark for reading an Arrow array to a vector}
 \format{
-An object of class \code{Benchmark} of length 8.
+An object of class \code{Benchmark} of length 9.
 }
 \usage{
 array_to_vector

--- a/man/dataset_taxi_parquet.Rd
+++ b/man/dataset_taxi_parquet.Rd
@@ -5,7 +5,7 @@
 \alias{dataset_taxi_parquet}
 \title{Benchmark Taxi dataset (Parquet) reading}
 \format{
-An object of class \code{Benchmark} of length 9.
+An object of class \code{Benchmark} of length 10.
 }
 \usage{
 dataset_taxi_parquet

--- a/man/df_to_table.Rd
+++ b/man/df_to_table.Rd
@@ -5,7 +5,7 @@
 \alias{df_to_table}
 \title{Benchmark for reading a data.frame into an Arrow table}
 \format{
-An object of class \code{Benchmark} of length 8.
+An object of class \code{Benchmark} of length 9.
 }
 \usage{
 df_to_table

--- a/man/placebo.Rd
+++ b/man/placebo.Rd
@@ -5,7 +5,7 @@
 \alias{placebo}
 \title{Placebo benchmark for testing}
 \format{
-An object of class \code{Benchmark} of length 8.
+An object of class \code{Benchmark} of length 9.
 }
 \usage{
 placebo

--- a/man/read_csv.Rd
+++ b/man/read_csv.Rd
@@ -5,7 +5,7 @@
 \alias{read_csv}
 \title{Benchmark CSV reading}
 \format{
-An object of class \code{Benchmark} of length 8.
+An object of class \code{Benchmark} of length 9.
 }
 \usage{
 read_csv

--- a/man/read_file.Rd
+++ b/man/read_file.Rd
@@ -5,7 +5,7 @@
 \alias{read_file}
 \title{Benchmark file reading}
 \format{
-An object of class \code{Benchmark} of length 8.
+An object of class \code{Benchmark} of length 9.
 }
 \usage{
 read_file

--- a/man/read_json.Rd
+++ b/man/read_json.Rd
@@ -5,7 +5,7 @@
 \alias{read_json}
 \title{Benchmark JSON reading}
 \format{
-An object of class \code{Benchmark} of length 8.
+An object of class \code{Benchmark} of length 9.
 }
 \usage{
 read_json

--- a/man/remote_dataset.Rd
+++ b/man/remote_dataset.Rd
@@ -5,7 +5,7 @@
 \alias{remote_dataset}
 \title{Remote (S3) dataset reading}
 \format{
-An object of class \code{Benchmark} of length 8.
+An object of class \code{Benchmark} of length 9.
 }
 \usage{
 remote_dataset

--- a/man/row_group_size.Rd
+++ b/man/row_group_size.Rd
@@ -5,7 +5,7 @@
 \alias{row_group_size}
 \title{Benchmark effect of parquet row group size}
 \format{
-An object of class \code{Benchmark} of length 8.
+An object of class \code{Benchmark} of length 9.
 }
 \usage{
 row_group_size

--- a/man/table_to_df.Rd
+++ b/man/table_to_df.Rd
@@ -5,7 +5,7 @@
 \alias{table_to_df}
 \title{Benchmark for reading an Arrow table to a data.frame}
 \format{
-An object of class \code{Benchmark} of length 8.
+An object of class \code{Benchmark} of length 9.
 }
 \usage{
 table_to_df

--- a/man/tpc_h.Rd
+++ b/man/tpc_h.Rd
@@ -5,7 +5,7 @@
 \alias{tpc_h}
 \title{Benchmark TPC-H queries}
 \format{
-An object of class \code{Benchmark} of length 8.
+An object of class \code{Benchmark} of length 9.
 }
 \usage{
 tpc_h

--- a/man/write_csv.Rd
+++ b/man/write_csv.Rd
@@ -5,7 +5,7 @@
 \alias{write_csv}
 \title{Benchmark CSV writing}
 \format{
-An object of class \code{Benchmark} of length 8.
+An object of class \code{Benchmark} of length 9.
 }
 \usage{
 write_csv

--- a/man/write_file.Rd
+++ b/man/write_file.Rd
@@ -5,7 +5,7 @@
 \alias{write_file}
 \title{Benchmark file writing}
 \format{
-An object of class \code{Benchmark} of length 8.
+An object of class \code{Benchmark} of length 9.
 }
 \usage{
 write_file

--- a/tests/testthat/test-result.R
+++ b/tests/testthat/test-result.R
@@ -23,7 +23,7 @@ test_that("R6.1 classes inherit properly", {
 
 test_that("inherited serialization/deserialization methods work", {
   res <- BenchmarkResult$new(
-    name = "fake",
+    benchmark = list(name = "fake", version = "1.0.0"),
     result = data.frame(time = 0, status = "superfast", stringsAsFactors = FALSE),
     params = list(speed = "lightning"),
     tags = c(is_real = FALSE)
@@ -31,7 +31,7 @@ test_that("inherited serialization/deserialization methods work", {
 
   # sanity
   expect_s3_class(res, "BenchmarkResult")
-  expect_equal(res$name, "fake")
+  expect_equal(res$benchmark, list(name = "fake", version = "1.0.0"))
 
   # roundtrips
   expect_equal(res$json, BenchmarkResult$from_json(res$json)$json)
@@ -45,7 +45,7 @@ test_that("inherited serialization/deserialization methods work", {
 
 test_that("S3 methods work", {
   res <- BenchmarkResult$new(
-    name = "fake",
+    benchmark = list(name = "fake", version = "1.0.0"),
     result = data.frame(time = 0, status = "superfast", stringsAsFactors = FALSE),
     params = list(speed = "lightning"),
     tags = c(is_real = FALSE)
@@ -60,7 +60,7 @@ test_that("S3 methods work", {
     structure(
       list(iteration = 1L, time = 0, status = "superfast", speed = "lightning"),
       row.names = c(NA, -1L), class = c("tbl_df", "tbl", "data.frame"),
-      name = "fake", tags = c(is_real = FALSE)
+      benchmark = list(name = "fake", version = "1.0.0"), tags = c(is_real = FALSE)
     )
   )
 

--- a/tests/testthat/test-run.R
+++ b/tests/testthat/test-run.R
@@ -1,5 +1,5 @@
 test_that("run_iteration", {
-  b <- Benchmark("test")
+  b <- Benchmark("test", version = "1.0.0")
   out <- run_iteration(b, ctx = new.env())
   expect_s3_class(out, "data.frame")
   expect_identical(nrow(out), 1L)
@@ -7,6 +7,7 @@ test_that("run_iteration", {
 
 test_that("run_bm", {
   b <- Benchmark("test",
+                 version = "1.0.0",
                  setup = function(param1 = c("a", "b")) {
                    BenchEnvironment(param1 = match.arg(param1))
                  },
@@ -124,7 +125,7 @@ test_that("form of the results, including output", {
   ))
 
   json_keys <- c(
-    "name", "tags", "info", "context", "github", "options", "result", "params",
+    "benchmark", "tags", "info", "context", "github", "options", "result", "params",
     "output", "rscript"
   )
   expect_named(res$results[[1]]$list, json_keys, ignore.order = TRUE)


### PR DESCRIPTION
Closes #101. Adds semantic versioning to benchmarks that can be incremented when benchmarks are altered. Alters JSON schema for results from

```json
{
  "name": "array_altrep_materialization",
  ...
}
```

to 

```json
{
  "benchmark": {
    "name": "array_altrep_materialization",
    "version": "1.0.0"
  },
  ...
}
```

as name and version together identify a benchmark. All versions are set to `1.0.0` for now.

These changes have not been implemented in conbench or ursacomputing/benchmarks yet, but since {benchmarks} is ignoring everything in the JSON except `blob.result.real`, this shouldn't break anything. However, {benchmarks} and {conbench} should be brought in line with this behavior; if we make this change, https://github.com/conbench/conbench/issues/314 will require simultaneous PRs to both {conbench} and {benchmarks} so as not to break anything.