### PR TITLE
Add capability to version cases

### DIFF
--- a/R/benchmark.R
+++ b/R/benchmark.R
@@ -82,6 +82,9 @@
 #' returning a `data.frame` of setup parameters. Use this to filter out invalid
 #' combinations of parameters (e.g. writing a Feather file with snappy
 #' compression, which is unsupported)
+#' @param case_version function taking a named list of setup parameters for a
+#' single case and returning an integer version for the case. Bump version to
+#' break conbench history for a case.
 #' @param ... additional attributes or functions, possibly called in `setup()`.
 #'
 #' @return A `Benchmark` object containing these functions
@@ -93,6 +96,7 @@ Benchmark <- function(name,
                       after_each = TRUE,
                       teardown = TRUE,
                       valid_params = function(params) params,
+                      case_version = function(params) 1L,
                       ...) {
   stopifnot(is.character(name))
   structure(
@@ -104,6 +108,7 @@ Benchmark <- function(name,
       after_each = substitute(after_each),
       teardown = substitute(teardown),
       valid_params = valid_params,
+      case_version = case_version,
       ...),
     class = "Benchmark"
   )

--- a/R/benchmark.R
+++ b/R/benchmark.R
@@ -84,7 +84,8 @@
 #' compression, which is unsupported)
 #' @param case_version function taking a named list of setup parameters for a
 #' single case and returning an integer version for the case, or `NULL` to not
-#' append a version. Changes to version will break conbench history for a case.
+#' append a version; `NA` will raise an error. Changes to version will break
+#' conbench history for a case.
 #' @param packages_used function taking a `data.frame` of setup parameters and
 #' returning a vector of R package names required
 #' @param ... additional attributes or functions, possibly called in `setup()`.

--- a/R/benchmark.R
+++ b/R/benchmark.R
@@ -83,8 +83,10 @@
 #' combinations of parameters (e.g. writing a Feather file with snappy
 #' compression, which is unsupported)
 #' @param case_version function taking a named list of setup parameters for a
-#' single case and returning an integer version for the case. Bump version to
-#' break conbench history for a case.
+#' single case and returning an integer version for the case, or `NULL` to not
+#' append a version. Changes to version will break conbench history for a case.
+#' @param packages_used function taking a `data.frame` of setup parameters and
+#' returning a vector of R package names required
 #' @param ... additional attributes or functions, possibly called in `setup()`.
 #'
 #' @return A `Benchmark` object containing these functions
@@ -96,7 +98,8 @@ Benchmark <- function(name,
                       after_each = TRUE,
                       teardown = TRUE,
                       valid_params = function(params) params,
-                      case_version = function(params) 1L,
+                      case_version = function(params) NULL,
+                      packages_used = function(params) "arrow",
                       ...) {
   stopifnot(is.character(name))
   structure(
@@ -109,6 +112,7 @@ Benchmark <- function(name,
       teardown = substitute(teardown),
       valid_params = valid_params,
       case_version = case_version,
+      packages_used = packages_used,
       ...),
     class = "Benchmark"
   )

--- a/R/run.R
+++ b/R/run.R
@@ -186,6 +186,8 @@ run_bm <- function(bm, ..., n_iter = 1, profiling = FALSE, global_params = list(
   defaults <- lapply(get_default_args(bm$setup), head, 1)
   defaults$cpu_count <- parallel::detectCores()
   params <- modifyList(defaults, list(...))
+  params$case_version <- bm$case_version(params)
+
   all_params <- modifyList(params, global_params)
   all_params$packages <- package_info()[, c("package", "loadedversion", "date", "source")]
   names(all_params$packages)[2] <- "version"

--- a/R/run.R
+++ b/R/run.R
@@ -186,7 +186,10 @@ run_bm <- function(bm, ..., n_iter = 1, profiling = FALSE, global_params = list(
   defaults <- lapply(get_default_args(bm$setup), head, 1)
   defaults$cpu_count <- parallel::detectCores()
   params <- modifyList(defaults, list(...))
-  params$case_version <- bm$case_version(params)
+
+  case_version <- bm$case_version(params)
+  stopifnot("Case versions may not be NA; use NULL for no versioning" = !is.na(case_version))
+  params$case_version <- case_version
 
   all_params <- modifyList(params, global_params)
   all_params$packages <- package_info()[, c("package", "loadedversion", "date", "source")]

--- a/man/Benchmark.Rd
+++ b/man/Benchmark.Rd
@@ -47,7 +47,8 @@ compression, which is unsupported)}
 
 \item{case_version}{function taking a named list of setup parameters for a
 single case and returning an integer version for the case, or \code{NULL} to not
-append a version. Changes to version will break conbench history for a case.}
+append a version; \code{NA} will raise an error. Changes to version will break
+conbench history for a case.}
 
 \item{packages_used}{function taking a \code{data.frame} of setup parameters and
 returning a vector of R package names required}

--- a/man/Benchmark.Rd
+++ b/man/Benchmark.Rd
@@ -12,7 +12,8 @@ Benchmark(
   after_each = TRUE,
   teardown = TRUE,
   valid_params = function(params) params,
-  case_version = function(params) 1L,
+  case_version = function(params) NULL,
+  packages_used = function(params) "arrow",
   ...
 )
 }
@@ -45,8 +46,11 @@ combinations of parameters (e.g. writing a Feather file with snappy
 compression, which is unsupported)}
 
 \item{case_version}{function taking a named list of setup parameters for a
-single case and returning an integer version for the case. Bump version to
-break conbench history for a case.}
+single case and returning an integer version for the case, or \code{NULL} to not
+append a version. Changes to version will break conbench history for a case.}
+
+\item{packages_used}{function taking a \code{data.frame} of setup parameters and
+returning a vector of R package names required}
 
 \item{...}{additional attributes or functions, possibly called in \code{setup()}.}
 }

--- a/man/Benchmark.Rd
+++ b/man/Benchmark.Rd
@@ -12,6 +12,7 @@ Benchmark(
   after_each = TRUE,
   teardown = TRUE,
   valid_params = function(params) params,
+  case_version = function(params) 1L,
   ...
 )
 }
@@ -42,6 +43,10 @@ affecting the benchmark results}
 returning a \code{data.frame} of setup parameters. Use this to filter out invalid
 combinations of parameters (e.g. writing a Feather file with snappy
 compression, which is unsupported)}
+
+\item{case_version}{function taking a named list of setup parameters for a
+single case and returning an integer version for the case. Bump version to
+break conbench history for a case.}
 
 \item{...}{additional attributes or functions, possibly called in \code{setup()}.}
 }

--- a/man/array_altrep_materialization.Rd
+++ b/man/array_altrep_materialization.Rd
@@ -5,7 +5,7 @@
 \alias{array_altrep_materialization}
 \title{Benchmark for materializing an altrep Arrow array}
 \format{
-An object of class \code{Benchmark} of length 8.
+An object of class \code{Benchmark} of length 9.
 }
 \usage{
 array_altrep_materialization

--- a/man/array_to_vector.Rd
+++ b/man/array_to_vector.Rd
@@ -5,7 +5,7 @@
 \alias{array_to_vector}
 \title{Benchmark for reading an Arrow array to a vector}
 \format{
-An object of class \code{Benchmark} of length 8.
+An object of class \code{Benchmark} of length 9.
 }
 \usage{
 array_to_vector

--- a/man/dataset_taxi_parquet.Rd
+++ b/man/dataset_taxi_parquet.Rd
@@ -5,7 +5,7 @@
 \alias{dataset_taxi_parquet}
 \title{Benchmark Taxi dataset (Parquet) reading}
 \format{
-An object of class \code{Benchmark} of length 9.
+An object of class \code{Benchmark} of length 10.
 }
 \usage{
 dataset_taxi_parquet

--- a/man/df_to_table.Rd
+++ b/man/df_to_table.Rd
@@ -5,7 +5,7 @@
 \alias{df_to_table}
 \title{Benchmark for reading a data.frame into an Arrow table}
 \format{
-An object of class \code{Benchmark} of length 8.
+An object of class \code{Benchmark} of length 9.
 }
 \usage{
 df_to_table

--- a/man/placebo.Rd
+++ b/man/placebo.Rd
@@ -5,7 +5,7 @@
 \alias{placebo}
 \title{Placebo benchmark for testing}
 \format{
-An object of class \code{Benchmark} of length 8.
+An object of class \code{Benchmark} of length 9.
 }
 \usage{
 placebo

--- a/man/read_csv.Rd
+++ b/man/read_csv.Rd
@@ -5,7 +5,7 @@
 \alias{read_csv}
 \title{Benchmark CSV reading}
 \format{
-An object of class \code{Benchmark} of length 8.
+An object of class \code{Benchmark} of length 9.
 }
 \usage{
 read_csv

--- a/man/read_file.Rd
+++ b/man/read_file.Rd
@@ -5,7 +5,7 @@
 \alias{read_file}
 \title{Benchmark file reading}
 \format{
-An object of class \code{Benchmark} of length 8.
+An object of class \code{Benchmark} of length 9.
 }
 \usage{
 read_file

--- a/man/read_json.Rd
+++ b/man/read_json.Rd
@@ -5,7 +5,7 @@
 \alias{read_json}
 \title{Benchmark JSON reading}
 \format{
-An object of class \code{Benchmark} of length 8.
+An object of class \code{Benchmark} of length 9.
 }
 \usage{
 read_json

--- a/man/remote_dataset.Rd
+++ b/man/remote_dataset.Rd
@@ -5,7 +5,7 @@
 \alias{remote_dataset}
 \title{Remote (S3) dataset reading}
 \format{
-An object of class \code{Benchmark} of length 8.
+An object of class \code{Benchmark} of length 9.
 }
 \usage{
 remote_dataset

--- a/man/row_group_size.Rd
+++ b/man/row_group_size.Rd
@@ -5,7 +5,7 @@
 \alias{row_group_size}
 \title{Benchmark effect of parquet row group size}
 \format{
-An object of class \code{Benchmark} of length 8.
+An object of class \code{Benchmark} of length 9.
 }
 \usage{
 row_group_size

--- a/man/table_to_df.Rd
+++ b/man/table_to_df.Rd
@@ -5,7 +5,7 @@
 \alias{table_to_df}
 \title{Benchmark for reading an Arrow table to a data.frame}
 \format{
-An object of class \code{Benchmark} of length 8.
+An object of class \code{Benchmark} of length 9.
 }
 \usage{
 table_to_df

--- a/man/tpc_h.Rd
+++ b/man/tpc_h.Rd
@@ -5,7 +5,7 @@
 \alias{tpc_h}
 \title{Benchmark TPC-H queries}
 \format{
-An object of class \code{Benchmark} of length 8.
+An object of class \code{Benchmark} of length 9.
 }
 \usage{
 tpc_h

--- a/man/write_csv.Rd
+++ b/man/write_csv.Rd
@@ -5,7 +5,7 @@
 \alias{write_csv}
 \title{Benchmark CSV writing}
 \format{
-An object of class \code{Benchmark} of length 8.
+An object of class \code{Benchmark} of length 9.
 }
 \usage{
 write_csv

--- a/man/write_file.Rd
+++ b/man/write_file.Rd
@@ -5,7 +5,7 @@
 \alias{write_file}
 \title{Benchmark file writing}
 \format{
-An object of class \code{Benchmark} of length 8.
+An object of class \code{Benchmark} of length 9.
 }
 \usage{
 write_file

--- a/tests/testthat/test-run.R
+++ b/tests/testthat/test-run.R
@@ -60,7 +60,7 @@ test_that("cases can be versioned", {
 
   expect_error(
     run_bm(bm_versioned, x = "novel value"),
-    regexp = "Case versions may not be NA; use NULL for no versioning"
+    regexp = "[Cc]ase[ _]version"  # 3.* stopifnot doesn't pass names as messages
   )
 })
 

--- a/tests/testthat/test-run.R
+++ b/tests/testthat/test-run.R
@@ -37,7 +37,7 @@ test_that("run_one", {
 test_that("cases can be versioned", {
   bm_unversioned <- Benchmark(
     "unversioned",
-    setup = function(x = c('foo', 'bar')) { cat(x) }
+    setup = function(x = c('foo', 'bar')) { force(x) }
   )
   res_unversioned <- run_benchmark(bm_unversioned)
   lapply(res_unversioned$results, function(result) {
@@ -57,6 +57,11 @@ test_that("cases can be versioned", {
     expected_version = c(foo = 1L, bar = 2L)[[result$params$x]]
     expect_equal(result$tags$case_version, expected_version)
   })
+
+  expect_error(
+    run_bm(bm_versioned, x = "novel value"),
+    regexp = "Case versions may not be NA; use NULL for no versioning"
+  )
 })
 
 test_that("get_params_summary returns a data.frame",{

--- a/tests/testthat/test-run.R
+++ b/tests/testthat/test-run.R
@@ -41,7 +41,7 @@ test_that("get_params_summary returns a data.frame",{
 
   expected_summary <- dplyr::tibble(
     duration = 0.01, grid = TRUE, cpu_count = 1L,
-    output_type = "message", lib_path = "latest", did_error = FALSE
+    output_type = "message", case_version = 1L, lib_path = "latest", did_error = FALSE
   )
   expect_identical(success_summary, expected_summary)
 


### PR DESCRIPTION
Successor to #104; closes #101. This PR inserts versioning for cases into params via a benchmark-configurable function that takes a case (a named list of params) and returns an integer version.

There are a couple important questions here:

1. Should version be inserted as a param in the JSON (and therefore in conbench)? We're already inserting a lot of stuff into params that's arguably metadata (`cpu_count`, `lib_path`, a dataframe of `packages`); at some point we should move this stuff to a metadata section.
2. What should the default behavior be? This sets everything to version `1L`, but I haven't quite figured out yet whether this will break _all_ the histories in conbench. If so, it's probably better to change it to default to not setting it.